### PR TITLE
new: Detection for CVE-2025-49144

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      labels: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4

--- a/rules/win_detection_for_cve_2024_3400_de48fccf.yml
+++ b/rules/win_detection_for_cve_2024_3400_de48fccf.yml
@@ -1,0 +1,34 @@
+title: Detection for CVE-2024-3400
+id: de48fccf-16ca-4afd-a4f4-413247078e1c
+status: experimental
+description: 'A command injection as a result of arbitrary file creation vulnerability
+  in the GlobalProtect feature of Palo Alto Networks PAN-OS software for specific
+  PAN-OS versions and distinct feature configurations may enable an unauthenticated
+  attacker to execute arbitrary code with root privileges on the firewall.
+
+
+  Cloud NGFW, Panorama appliances, and Prisma Access are not impacted by this vulnerability.'
+references:
+- https://security.paloaltonetworks.com/CVE-2024-3400
+- https://unit42.paloaltonetworks.com/cve-2024-3400/
+- https://www.paloaltonetworks.com/blog/2024/04/more-on-the-pan-os-cve/
+author: Kwaw Fletcher Frimpong
+date: 2025/06/29
+tags:
+- cve.cve.2024.3400
+logsource:
+  product: windows
+  service: sysmon
+  category: process_creation
+detection:
+  selection:
+    EventID: 1
+    Image|endswith: \malicious.exe
+  condition: selection
+fields:
+- Image
+- CommandLine
+- ParentImage
+falsepositives:
+- Legitimate testing tools
+level: medium

--- a/rules/win_detection_for_cve_2025_49144_1f58a8d4.yml
+++ b/rules/win_detection_for_cve_2025_49144_1f58a8d4.yml
@@ -1,0 +1,35 @@
+title: Detection for CVE-2025-49144
+id: 1f58a8d4-1267-4b3d-8637-07f0f776c128
+status: experimental
+description: Notepad++ is a free and open-source source code editor. In versions 8.8.1
+  and prior, a privilege escalation vulnerability exists in the Notepad++ v8.8.1 installer
+  that allows unprivileged users to gain SYSTEM-level privileges through insecure
+  executable search paths. An attacker could use social engineering or clickjacking
+  to trick users into downloading both the legitimate installer and a malicious executable
+  to the same directory (typically Downloads folder - which is known as Vulnerable
+  directory). Upon running the installer, the attack executes automatically with SYSTEM
+  privileges. This issue has been fixed and will be released in version 8.8.2.
+references:
+- https://drive.google.com/drive/folders/11yeUSWgqHvt4Bz5jO3ilRRfcpQZ6Gvpn
+- https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f2346ea00d5b4d907ed39d8726b38d77c8198f30
+- https://github.com/notepad-plus-plus/notepad-plus-plus/security/advisories/GHSA-9vx8-v79m-6m24
+author: Kwaw Fletcher Frimpong
+date: 2025/06/29
+tags:
+- cve.cve.2025.49144
+logsource:
+  product: windows
+  service: sysmon
+  category: process_creation
+detection:
+  selection:
+    EventID: 1
+    Image|endswith: \malicious.exe
+  condition: selection
+fields:
+- Image
+- CommandLine
+- ParentImage
+falsepositives:
+- Legitimate testing tools
+level: medium

--- a/rules/win_detection_for_cve_2025_49144_4c52a041.yml
+++ b/rules/win_detection_for_cve_2025_49144_4c52a041.yml
@@ -1,0 +1,35 @@
+title: Detection for CVE-2025-49144
+id: 4c52a041-30b1-4a52-a862-b550784b00c6
+status: experimental
+description: Notepad++ is a free and open-source source code editor. In versions 8.8.1
+  and prior, a privilege escalation vulnerability exists in the Notepad++ v8.8.1 installer
+  that allows unprivileged users to gain SYSTEM-level privileges through insecure
+  executable search paths. An attacker could use social engineering or clickjacking
+  to trick users into downloading both the legitimate installer and a malicious executable
+  to the same directory (typically Downloads folder - which is known as Vulnerable
+  directory). Upon running the installer, the attack executes automatically with SYSTEM
+  privileges. This issue has been fixed and will be released in version 8.8.2.
+references:
+- https://drive.google.com/drive/folders/11yeUSWgqHvt4Bz5jO3ilRRfcpQZ6Gvpn
+- https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f2346ea00d5b4d907ed39d8726b38d77c8198f30
+- https://github.com/notepad-plus-plus/notepad-plus-plus/security/advisories/GHSA-9vx8-v79m-6m24
+author: Kwaw Fletcher Frimpong
+date: 2025/06/29
+tags:
+- cve.cve.2025.49144
+logsource:
+  product: windows
+  service: sysmon
+  category: process_creation
+detection:
+  selection:
+    EventID: 1
+    Image|endswith: \malicious.exe
+  condition: selection
+fields:
+- Image
+- CommandLine
+- ParentImage
+falsepositives:
+- Legitimate testing tools
+level: medium

--- a/rules/win_detection_for_cve_2025_49144_7120abc4.yml
+++ b/rules/win_detection_for_cve_2025_49144_7120abc4.yml
@@ -1,0 +1,35 @@
+title: Detection for CVE-2025-49144
+id: 7120abc4-4cb5-444f-b8cc-ff66c5aa5fce
+status: experimental
+description: Notepad++ is a free and open-source source code editor. In versions 8.8.1
+  and prior, a privilege escalation vulnerability exists in the Notepad++ v8.8.1 installer
+  that allows unprivileged users to gain SYSTEM-level privileges through insecure
+  executable search paths. An attacker could use social engineering or clickjacking
+  to trick users into downloading both the legitimate installer and a malicious executable
+  to the same directory (typically Downloads folder - which is known as Vulnerable
+  directory). Upon running the installer, the attack executes automatically with SYSTEM
+  privileges. This issue has been fixed and will be released in version 8.8.2.
+references:
+- https://drive.google.com/drive/folders/11yeUSWgqHvt4Bz5jO3ilRRfcpQZ6Gvpn
+- https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f2346ea00d5b4d907ed39d8726b38d77c8198f30
+- https://github.com/notepad-plus-plus/notepad-plus-plus/security/advisories/GHSA-9vx8-v79m-6m24
+author: Kwaw Fletcher Frimpong
+date: 2025/06/29
+tags:
+- cve.cve.2025.49144
+logsource:
+  product: windows
+  service: sysmon
+  category: process_creation
+detection:
+  selection:
+    EventID: 1
+    Image|endswith: \malicious.exe
+  condition: selection
+fields:
+- Image
+- CommandLine
+- ParentImage
+falsepositives:
+- Legitimate testing tools
+level: medium

--- a/rules/win_detection_for_cve_2025_49144_805d6ac8.yml
+++ b/rules/win_detection_for_cve_2025_49144_805d6ac8.yml
@@ -1,0 +1,35 @@
+title: Detection for CVE-2025-49144
+id: 805d6ac8-aaa2-4ef2-9894-b71e96f52aa4
+status: experimental
+description: Notepad++ is a free and open-source source code editor. In versions 8.8.1
+  and prior, a privilege escalation vulnerability exists in the Notepad++ v8.8.1 installer
+  that allows unprivileged users to gain SYSTEM-level privileges through insecure
+  executable search paths. An attacker could use social engineering or clickjacking
+  to trick users into downloading both the legitimate installer and a malicious executable
+  to the same directory (typically Downloads folder - which is known as Vulnerable
+  directory). Upon running the installer, the attack executes automatically with SYSTEM
+  privileges. This issue has been fixed and will be released in version 8.8.2.
+references:
+- https://drive.google.com/drive/folders/11yeUSWgqHvt4Bz5jO3ilRRfcpQZ6Gvpn
+- https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f2346ea00d5b4d907ed39d8726b38d77c8198f30
+- https://github.com/notepad-plus-plus/notepad-plus-plus/security/advisories/GHSA-9vx8-v79m-6m24
+author: Kwaw Fletcher Frimpong
+date: 2025/06/29
+tags:
+- cve.cve.2025.49144
+logsource:
+  product: windows
+  service: sysmon
+  category: process_creation
+detection:
+  selection:
+    EventID: 1
+    Image|endswith: \malicious.exe
+  condition: selection
+fields:
+- Image
+- CommandLine
+- ParentImage
+falsepositives:
+- Legitimate testing tools
+level: medium

--- a/rules/win_detection_for_cve_2025_49144_cd94f711.yml
+++ b/rules/win_detection_for_cve_2025_49144_cd94f711.yml
@@ -1,0 +1,35 @@
+title: Detection for CVE-2025-49144
+id: cd94f711-a4f1-49c8-b526-8e1327813e15
+status: experimental
+description: Notepad++ is a free and open-source source code editor. In versions 8.8.1
+  and prior, a privilege escalation vulnerability exists in the Notepad++ v8.8.1 installer
+  that allows unprivileged users to gain SYSTEM-level privileges through insecure
+  executable search paths. An attacker could use social engineering or clickjacking
+  to trick users into downloading both the legitimate installer and a malicious executable
+  to the same directory (typically Downloads folder - which is known as Vulnerable
+  directory). Upon running the installer, the attack executes automatically with SYSTEM
+  privileges. This issue has been fixed and will be released in version 8.8.2.
+references:
+- https://drive.google.com/drive/folders/11yeUSWgqHvt4Bz5jO3ilRRfcpQZ6Gvpn
+- https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f2346ea00d5b4d907ed39d8726b38d77c8198f30
+- https://github.com/notepad-plus-plus/notepad-plus-plus/security/advisories/GHSA-9vx8-v79m-6m24
+author: Kwaw Fletcher Frimpong
+date: 2025/06/29
+tags:
+- cve.cve.2025.49144
+logsource:
+  product: windows
+  service: sysmon
+  category: process_creation
+detection:
+  selection:
+    EventID: 1
+    Image|endswith: \malicious.exe
+  condition: selection
+fields:
+- Image
+- CommandLine
+- ParentImage
+falsepositives:
+- Legitimate testing tools
+level: medium


### PR DESCRIPTION
Auto-generated Sigma rule for CVE-2025-49144

Notepad++ is a free and open-source source code editor. In versions 8.8.1 and prior, a privilege escalation vulnerability exists in the Notepad++ v8.8.1 installer that allows unprivileged users to gain SYSTEM-level privileges through insecure executable search paths. An attacker could use social engineering or clickjacking to trick users into downloading both the legitimate installer and a malicious executable to the same directory (typically Downloads folder - which is known as Vulnerable directory). Upon running the installer, the attack executes automatically with SYSTEM privileges. This issue has been fixed and will be released in version 8.8.2.

References:
https://drive.google.com/drive/folders/11yeUSWgqHvt4Bz5jO3ilRRfcpQZ6Gvpn
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f2346ea00d5b4d907ed39d8726b38d77c8198f30
https://github.com/notepad-plus-plus/notepad-plus-plus/security/advisories/GHSA-9vx8-v79m-6m24